### PR TITLE
Extract cytoscape shapes

### DIFF
--- a/frontend/src/util/shapes.ts
+++ b/frontend/src/util/shapes.ts
@@ -1,23 +1,19 @@
 import cytoscape from "cytoscape";
+import { omit } from "lodash";
 
-export type NodeShape = {
-  name: string;
-  points?: number[];
-};
+type NodeShapesRecord = Record<cytoscape.Css.NodeShape, { points?: number[] }>;
 
 type CytoscapeRenderer = {
   prototype: {
     registerNodeShapes: () => void;
-    nodeShapes: Record<string, NodeShape>;
+    nodeShapes: NodeShapesRecord;
   };
 };
 
 /** initialise cytoscape base renderer extension and access only nodeShapes */
-export const nodeShapes = ((): Record<string, NodeShape> => {
+export const nodeShapes = ((): NodeShapesRecord => {
   const baseRenderer = cytoscape("renderer", "base") as CytoscapeRenderer;
   baseRenderer.prototype.registerNodeShapes();
   const shapes = baseRenderer.prototype.nodeShapes;
-  return Object.fromEntries(
-    Object.entries(shapes).filter(([key]) => key !== "makePolygon"),
-  );
+  return omit(shapes, "makePolygon");
 })();

--- a/frontend/src/util/shapes.ts
+++ b/frontend/src/util/shapes.ts
@@ -1,0 +1,23 @@
+import cytoscape from "cytoscape";
+
+export type NodeShape = {
+  name: string;
+  points?: number[];
+};
+
+type CytoscapeRenderer = {
+  prototype: {
+    registerNodeShapes: () => void;
+    nodeShapes: Record<string, NodeShape>;
+  };
+};
+
+/** initialise cytoscape base renderer extension and access only nodeShapes */
+export const nodeShapes = ((): Record<string, NodeShape> => {
+  const baseRenderer = cytoscape("renderer", "base") as CytoscapeRenderer;
+  baseRenderer.prototype.registerNodeShapes();
+  const shapes = baseRenderer.prototype.nodeShapes;
+  return Object.fromEntries(
+    Object.entries(shapes).filter(([key]) => key !== "makePolygon"),
+  );
+})();


### PR DESCRIPTION
Closes #20

- Extract node shape raw geometric points from Cytoscape's base renderer
- Create and export `nodeShapes` object with all predefined shapes (filtering out the `makePolygon` function)