### PR TITLE
Table of contents and about page rework

### DIFF
--- a/frontend/src/components/Chart.tsx
+++ b/frontend/src/components/Chart.tsx
@@ -211,7 +211,7 @@ const Chart = ({
   if (printing) return createPortal(chart, document.body);
 
   return (
-    <Flex direction="column" gap="lg" full>
+    <Flex column gap="lg" full>
       {chart}
 
       {/* controls */}

--- a/frontend/src/components/Dialog.tsx
+++ b/frontend/src/components/Dialog.tsx
@@ -40,13 +40,13 @@ const Dialog = ({ title, content, bottomContent, children }: Props) => {
       <Root open={open} onClose={close}>
         <div className={classes.fullscreen}>
           <Content as={Fragment}>
-            <Flex direction="column" className={classes.content}>
+            <Flex column className={classes.content}>
               <Title>{title}</Title>
               <Description className="sr-only">{title}</Description>
               <button className={classes.close} onClick={close}>
                 <FaCircleXmark />
               </button>
-              <Flex className={classes.scroll} direction="column">
+              <Flex className={classes.scroll} column>
                 {content}
               </Flex>
               {bottomContent && (

--- a/frontend/src/components/Download.tsx
+++ b/frontend/src/components/Download.tsx
@@ -51,7 +51,7 @@ const Download = ({
   return (
     <Popover
       content={
-        <Flex direction="column" hAlign="stretch" gap="xs">
+        <Flex column hAlign="stretch" gap="xs">
           {raster && (
             <>
               <Button

--- a/frontend/src/components/FeatureCard.tsx
+++ b/frontend/src/components/FeatureCard.tsx
@@ -16,7 +16,7 @@ type Props = {
 /** card with title, badge, and text/image */
 const FeatureCard = ({ title, badge, content }: Props) => {
   return (
-    <Flex direction="column" className={clsx("card", classes.card)}>
+    <Flex column className={clsx("card", classes.card)}>
       <Flex wrap={false} gap="sm" className={clsx("full", classes.title)}>
         <span className="primary">{title}</span>
         {badge && <Badge className={classes.badge}>{badge}</Badge>}

--- a/frontend/src/components/Flex.tsx
+++ b/frontend/src/components/Flex.tsx
@@ -7,17 +7,17 @@ type Props<TagName extends TagNames = "div"> = {
   /** tag name */
   tag?: TagNames;
   /** flex display (whether container takes up full width) */
-  display?: "block" | "inline";
-  /** horizontal or vertical */
-  direction?: "row" | "column";
+  inline?: boolean;
+  /** vertical layout instead of horizontal */
+  column?: boolean;
   /** amount of space between items */
   gap?: "md" | "none" | "xs" | "sm" | "lg" | "xl";
   /** vertical gap fraction of horizontal gap */
   gapRatio?: 1 | 0.5 | 0.25 | 0;
   /** whether to wrap items */
-  wrap?: true | false;
+  wrap?: boolean;
   /** whether to make full width */
-  full?: true | false;
+  full?: boolean;
   /** horizontal alignment */
   hAlign?: "center" | "left" | "right" | "stretch" | "space";
   /** vertical alignment */
@@ -51,8 +51,8 @@ const gapMap: Record<NonNullable<Props["gap"]>, number> = {
 const Flex = <TagName extends TagNames>({
   ref,
   tag: Tag = "div",
-  display = "block",
-  direction = "row",
+  inline = false,
+  column = false,
   gap = "md",
   gapRatio = 1,
   wrap = true,
@@ -66,12 +66,11 @@ const Flex = <TagName extends TagNames>({
   const belowBreakpoint = useMediaQuery(`(max-width: ${breakpoint}px)`);
 
   const flexStyles: CSSProperties = {
-    display: display === "block" ? "flex" : "inline-flex",
-    flexDirection: direction === "column" || belowBreakpoint ? "column" : "row",
-    justifyContent:
-      direction === "column" ? alignMap[vAlign] : alignMap[hAlign],
-    alignItems: direction === "column" ? alignMap[hAlign] : alignMap[vAlign],
-    flexWrap: wrap && direction === "row" ? "wrap" : "nowrap",
+    display: inline ? "inline-flex" : "flex",
+    flexDirection: column || belowBreakpoint ? "column" : "row",
+    justifyContent: column ? alignMap[vAlign] : alignMap[hAlign],
+    alignItems: column ? alignMap[hAlign] : alignMap[vAlign],
+    flexWrap: wrap && !column ? "wrap" : "nowrap",
     gap: `${gapMap[gap] * gapRatio}px ${gapMap[gap]}px`,
     width: full ? "100%" : undefined,
     ...style,

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -5,7 +5,7 @@ import classes from "./Footer.module.css";
 
 /** at bottom of every page. singleton. */
 const Footer = () => (
-  <Flex tag="footer" direction="column" gap="sm" className={classes.footer}>
+  <Flex tag="footer" column gap="sm" className={classes.footer}>
     <Flex gap="sm" className={classes.icons}>
       <Link
         to="mailto:janani.ravi@cuanschutz.edu"

--- a/frontend/src/components/Heading.module.css
+++ b/frontend/src/components/Heading.module.css
@@ -17,10 +17,6 @@ h4.heading {
   text-align: left;
 }
 
-:is(h3.heading, h4.heading) + :not(h3.heading, h4.heading) {
-  margin-top: -1em;
-}
-
 .icon {
   color: var(--deep);
 }

--- a/frontend/src/components/Heading.tsx
+++ b/frontend/src/components/Heading.tsx
@@ -61,16 +61,23 @@ const Heading = ({
 
   const setHeadings = useSetAtom(headingsAtom);
 
+  /** on every render */
   useEffect(() => {
     const element = ref.current;
 
     if (element) {
       setHeadings((headings) =>
         headings
+          /** remove heading from list */
           .filter((heading) => heading.ref !== element)
+          /** add heading to list */
           .concat([
             { ref: element, id, level, icon: iconElement, text: children },
           ])
+          /**
+           * make sure list is in order of document appearance
+           * https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition
+           */
           .sort((a, b) =>
             a.ref.compareDocumentPosition(b.ref) &
             Node.DOCUMENT_POSITION_FOLLOWING
@@ -81,6 +88,7 @@ const Heading = ({
     }
 
     return () =>
+      /** remove heading from list */
       setHeadings((headings) =>
         headings.filter((heading) => heading.ref !== element),
       );

--- a/frontend/src/components/Mark.tsx
+++ b/frontend/src/components/Mark.tsx
@@ -39,7 +39,7 @@ export type Type = keyof typeof types;
 /** icon and text with color */
 const Mark = ({ type = "info", icon, className, children }: Props) => (
   <Flex
-    display="inline"
+    inline
     gap="sm"
     wrap={false}
     className={clsx(className, classes.mark)}

--- a/frontend/src/components/Network.tsx
+++ b/frontend/src/components/Network.tsx
@@ -605,7 +605,7 @@ const Network = ({ filename = [], nodes: _nodes, edges: _edges }: Props) => {
   const [, { toggleFullscreen }] = useFullscreen(containerRef);
 
   return (
-    <Flex direction="column" full>
+    <Flex column full>
       <div
         ref={ref}
         className={clsx("card", classes.network, expanded && classes.expanded)}
@@ -613,7 +613,7 @@ const Network = ({ filename = [], nodes: _nodes, edges: _edges }: Props) => {
       >
         {/* panel */}
         <Flex
-          direction="column"
+          column
           hAlign="left"
           vAlign="top"
           className={classes.panel}
@@ -622,7 +622,7 @@ const Network = ({ filename = [], nodes: _nodes, edges: _edges }: Props) => {
           {selectedItems.length ? (
             /** show info about selected nodes/edges */
             <>
-              <Flex direction="column" hAlign="left" gap="sm">
+              <Flex column hAlign="left" gap="sm">
                 <strong>Selected items</strong>
                 {selectedItems.map((node, index) => (
                   <Fragment key={index}>
@@ -656,7 +656,7 @@ const Network = ({ filename = [], nodes: _nodes, edges: _edges }: Props) => {
           ) : (
             /** if nothing selected, show color key */
             <>
-              <Flex direction="column" hAlign="left" gap="sm">
+              <Flex column hAlign="left" gap="sm">
                 <div>
                   <strong>Nodes</strong>{" "}
                   <span className="secondary">
@@ -672,7 +672,7 @@ const Network = ({ filename = [], nodes: _nodes, edges: _edges }: Props) => {
                 />
               </Flex>
 
-              <Flex direction="column" hAlign="left" gap="sm">
+              <Flex column hAlign="left" gap="sm">
                 <div>
                   <strong>Edges</strong>{" "}
                   <span className="secondary">

--- a/frontend/src/components/Radios.tsx
+++ b/frontend/src/components/Radios.tsx
@@ -77,12 +77,7 @@ const Radios = <O extends Option>({
   }, [value]);
 
   return (
-    <Flex
-      column
-      hAlign="left"
-      role="group"
-      className={classes.container}
-    >
+    <Flex column hAlign="left" role="group" className={classes.container}>
       <legend className={classes.label}>
         {label}
         {tooltip && <Help tooltip={tooltip} />}
@@ -118,14 +113,7 @@ const Radios = <O extends Option>({
 
             {/* text content */}
             <Flex column hAlign="left" gap="sm">
-              <span
-                className={clsx(
-                  "primary",
-                  selectedWFallback === option.id && classes.checked,
-                )}
-              >
-                {option.primary}
-              </span>
+              <span className="primary">{option.primary}</span>
               {option.secondary && (
                 <span className="secondary">{option.secondary}</span>
               )}

--- a/frontend/src/components/Radios.tsx
+++ b/frontend/src/components/Radios.tsx
@@ -78,7 +78,7 @@ const Radios = <O extends Option>({
 
   return (
     <Flex
-      direction="column"
+      column
       hAlign="left"
       role="group"
       className={classes.container}
@@ -88,7 +88,7 @@ const Radios = <O extends Option>({
         {tooltip && <Help tooltip={tooltip} />}
       </legend>
 
-      <Flex direction="column" gap="xs" hAlign="stretch">
+      <Flex column gap="xs" hAlign="stretch">
         {options.map((option, index) => (
           <Flex
             tag="label"
@@ -117,7 +117,7 @@ const Radios = <O extends Option>({
             )}
 
             {/* text content */}
-            <Flex direction="column" hAlign="left" gap="sm">
+            <Flex column hAlign="left" gap="sm">
               <span
                 className={clsx(
                   "primary",

--- a/frontend/src/components/Section.tsx
+++ b/frontend/src/components/Section.tsx
@@ -22,7 +22,7 @@ type Props = {
 const Section = ({ fill, full, className, ...props }: Props) => (
   <Flex
     tag="section"
-    direction="column"
+    column
     gap="lg"
     vAlign="top"
     className={clsx(className, classes.section, {

--- a/frontend/src/components/Select.module.css
+++ b/frontend/src/components/Select.module.css
@@ -61,7 +61,7 @@
   transition: background var(--fast);
 }
 
-.option-active {
+.option[data-active="true"] {
   background: var(--off-white);
 }
 

--- a/frontend/src/components/SelectMulti.tsx
+++ b/frontend/src/components/SelectMulti.tsx
@@ -105,12 +105,7 @@ const SelectMulti = <O extends Option>({
               {options.map((option) => (
                 <ListboxOption key={option.id} value={option.id} as={Fragment}>
                   {({ focus, selected }) => (
-                    <li
-                      className={clsx(
-                        classes.option,
-                        focus && classes["option-active"],
-                      )}
-                    >
+                    <li className={classes.option} data-active={focus}>
                       <FaCheck
                         className={classes.check}
                         style={{ opacity: selected ? 1 : 0 }}

--- a/frontend/src/components/SelectSingle.tsx
+++ b/frontend/src/components/SelectSingle.tsx
@@ -141,12 +141,7 @@ const SelectSingle = <O extends Option>({
         {options.map((option) => (
           <ListboxOption key={option.id} value={option.id} as={Fragment}>
             {({ focus, selected }) => (
-              <li
-                className={clsx(
-                  classes.option,
-                  focus && classes["option-active"],
-                )}
-              >
+              <li className={classes.option} data-active={focus}>
                 {/* check mark */}
                 <VscCircleFilled
                   className={classes.check}

--- a/frontend/src/components/Table.module.css
+++ b/frontend/src/components/Table.module.css
@@ -32,7 +32,7 @@
   color: var(--deep);
 }
 
-.header-button-active {
+.header-button[data-active="true"] {
   color: var(--accent);
 }
 

--- a/frontend/src/components/Table.module.css
+++ b/frontend/src/components/Table.module.css
@@ -6,13 +6,6 @@
   width: calc(100vw - 40px);
 }
 
-.scroll {
-  max-width: 100%;
-  overflow-x: auto;
-  border-radius: var(--rounded);
-  box-shadow: var(--box-shadow);
-}
-
 @media (max-width: 800px) {
   .expanded th,
   .expanded td {
@@ -39,7 +32,7 @@
   color: var(--deep);
 }
 
-.header-button[data-active] {
+.header-button-active {
   color: var(--accent);
 }
 

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -13,7 +13,6 @@ import {
   FaSortUp,
 } from "react-icons/fa6";
 import { MdFilterAltOff } from "react-icons/md";
-import clsx from "clsx";
 import { clamp, isEqual, pick, sortBy, sum } from "lodash";
 import { useLocalStorage } from "@reactuses/core";
 import {
@@ -277,10 +276,7 @@ const Table = <Datum extends object>({
   });
 
   return (
-    <Flex
-      column
-      className={expanded ? classes.expanded : classes.collapsed}
-    >
+    <Flex column className={expanded ? classes.expanded : classes.collapsed}>
       <div className="table-wrapper">
         {/* table */}
         <table
@@ -320,11 +316,8 @@ const Table = <Datum extends object>({
                           <Tooltip content="Sort this column">
                             <button
                               type="button"
-                              className={clsx(
-                                classes["header-button"],
-                                header.column.getIsSorted() &&
-                                  classes["header-button-active"],
-                              )}
+                              className={classes["header-button"]}
+                              data-active={header.column.getIsSorted()}
                               onClick={header.column.getToggleSortingHandler()}
                             >
                               {header.column.getIsSorted() ? (
@@ -353,11 +346,8 @@ const Table = <Datum extends object>({
                             <Tooltip content="Filter this column">
                               <button
                                 type="button"
-                                className={clsx(
-                                  classes["header-button"],
-                                  header.column.getIsFiltered() &&
-                                    classes["header-button-active"],
-                                )}
+                                className={classes["header-button"]}
+                                data-active={header.column.getIsFiltered()}
                               >
                                 <FaFilter />
                               </button>

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -13,6 +13,7 @@ import {
   FaSortUp,
 } from "react-icons/fa6";
 import { MdFilterAltOff } from "react-icons/md";
+import clsx from "clsx";
 import { clamp, isEqual, pick, sortBy, sum } from "lodash";
 import { useLocalStorage } from "@reactuses/core";
 import {
@@ -277,10 +278,10 @@ const Table = <Datum extends object>({
 
   return (
     <Flex
-      direction="column"
+      column
       className={expanded ? classes.expanded : classes.collapsed}
     >
-      <div className={classes.scroll}>
+      <div className="table-wrapper">
         {/* table */}
         <table
           className={classes.table}
@@ -319,10 +320,11 @@ const Table = <Datum extends object>({
                           <Tooltip content="Sort this column">
                             <button
                               type="button"
-                              className={classes["header-button"]}
-                              data-active={
-                                header.column.getIsSorted() ? "" : undefined
-                              }
+                              className={clsx(
+                                classes["header-button"],
+                                header.column.getIsSorted() &&
+                                  classes["header-button-active"],
+                              )}
                               onClick={header.column.getToggleSortingHandler()}
                             >
                               {header.column.getIsSorted() ? (
@@ -351,10 +353,11 @@ const Table = <Datum extends object>({
                             <Tooltip content="Filter this column">
                               <button
                                 type="button"
-                                className={classes["header-button"]}
-                                data-active={
-                                  header.column.getIsFiltered() ? "" : undefined
-                                }
+                                className={clsx(
+                                  classes["header-button"],
+                                  header.column.getIsFiltered() &&
+                                    classes["header-button-active"],
+                                )}
                               >
                                 <FaFilter />
                               </button>

--- a/frontend/src/components/TableOfContents.module.css
+++ b/frontend/src/components/TableOfContents.module.css
@@ -56,7 +56,7 @@
   color: var(--accent);
 }
 
-.link-active {
+.link[data-active="true"] {
   background: var(--off-white);
   color: var(--accent);
   font-weight: var(--bold);

--- a/frontend/src/components/TableOfContents.module.css
+++ b/frontend/src/components/TableOfContents.module.css
@@ -41,14 +41,12 @@
 }
 
 .link {
-  display: inline-block;
+  display: flex;
   flex-shrink: 0;
+  align-items: center;
   padding: 5px 10px;
-  overflow: hidden;
   color: var(--dark-gray);
   text-decoration: none;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   transition:
     background var(--fast),
     color var(--fast);
@@ -58,8 +56,21 @@
   color: var(--accent);
 }
 
-.link[data-active] {
+.link-active {
   background: var(--off-white);
   color: var(--accent);
   font-weight: var(--bold);
+}
+
+.link-text {
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.link-icon {
+  display: grid;
+  place-items: center;
+  opacity: 0.25;
 }

--- a/frontend/src/components/TableOfContents.tsx
+++ b/frontend/src/components/TableOfContents.tsx
@@ -99,10 +99,8 @@ const TableOfContents = () => {
             <Link
               key={index}
               ref={active === index ? activeRef : undefined}
-              className={clsx(
-                classes.link,
-                active === index && classes["link-active"],
-              )}
+              className={classes.link}
+              data-active={active === index}
               to={{ hash: "#" + id }}
               replace
               style={{ paddingLeft: 20 * (level - 0.5) }}

--- a/frontend/src/components/TableOfContents.tsx
+++ b/frontend/src/components/TableOfContents.tsx
@@ -1,25 +1,15 @@
 import { useRef, useState } from "react";
 import { FaBars, FaXmark } from "react-icons/fa6";
 import clsx from "clsx";
+import { useAtomValue } from "jotai";
 import { debounce } from "lodash";
-import {
-  useClickOutside,
-  useEventListener,
-  useMutationObserver,
-} from "@reactuses/core";
+import { useClickOutside, useEventListener } from "@reactuses/core";
+import { headingsAtom } from "@/components/Heading";
 import Link from "@/components/Link";
 import Tooltip from "@/components/Tooltip";
 import { firstInView, isCovering, scrollTo } from "@/util/dom";
 import { sleep } from "@/util/misc";
 import classes from "./TableOfContents.module.css";
-
-/** all used heading elements */
-const headingSelector = "h1, h2, h3, h4";
-
-/** get all used heading elements */
-const getHeadings = () => [
-  ...document.querySelectorAll<HTMLHeadingElement>(headingSelector),
-];
 
 /**
  * check if covering something important and run func to close. debounce to
@@ -45,12 +35,10 @@ const TableOfContents = () => {
   const [open, setOpen] = useState(window.innerWidth > 1500);
 
   /** full heading details */
-  const [headings, setHeadings] = useState<
-    { text: string; id: string; level: number }[]
-  >([]);
+  const headings = useAtomValue(headingsAtom);
 
-  /** active heading id (first in view) */
-  const [activeId, setActiveId] = useState("");
+  /** active index */
+  const [active, setActive] = useState(0);
 
   /** click off to close */
   useClickOutside(ref, async () => {
@@ -62,10 +50,12 @@ const TableOfContents = () => {
   /** on window scroll */
   useEventListener("scroll", () => {
     /** get active heading */
-    setActiveId(firstInView(getHeadings())?.id || "");
+    setActive(firstInView(headings.map((h) => h.ref)));
+
     if (open) {
       /** if covering something important, close */
       debouncedIsCovering(ref.current, () => setOpen(false));
+
       /** prevent jitter when pinch-zoomed in */
       if (window.visualViewport?.scale === 1)
         /** scroll active toc item into view */
@@ -75,26 +65,6 @@ const TableOfContents = () => {
         });
     }
   });
-
-  useMutationObserver(
-    () => {
-      /** read headings from page */
-      setHeadings(
-        getHeadings().map((heading) => ({
-          text: heading.innerText,
-          id: heading.id,
-          level: parseInt(heading.tagName.slice(1)) || 0,
-        })),
-      );
-    },
-    /** listen to changes on page */
-    document.documentElement,
-    /** only listen for elements added/removed */
-    {
-      subtree: true,
-      childList: true,
-    },
-  );
 
   /** if not much value in showing toc, hide */
   if (headings.length <= 1) return <></>;
@@ -125,18 +95,21 @@ const TableOfContents = () => {
       {/* links */}
       {open && (
         <div ref={listRef} className={classes.list}>
-          {headings.map((heading, index) => (
+          {headings.map(({ id, level, text, icon }, index) => (
             <Link
               key={index}
-              ref={heading.id === activeId ? activeRef : undefined}
-              data-active={heading.id === activeId ? "" : undefined}
-              className={classes.link}
-              to={{ hash: "#" + heading.id }}
+              ref={active === index ? activeRef : undefined}
+              className={clsx(
+                classes.link,
+                active === index && classes["link-active"],
+              )}
+              to={{ hash: "#" + id }}
               replace
-              style={{ paddingLeft: 10 * heading.level }}
-              onClick={() => scrollTo("#" + heading.id)}
+              style={{ paddingLeft: 20 * (level - 0.5) }}
+              onClick={() => scrollTo("#" + id)}
             >
-              {heading.text}
+              {icon && <span className={classes["link-icon"]}>{icon}</span>}
+              <span className={classes["link-text"]}>{text}</span>
             </Link>
           ))}
         </div>

--- a/frontend/src/components/Tabs.module.css
+++ b/frontend/src/components/Tabs.module.css
@@ -26,7 +26,7 @@
   color: var(--deep);
 }
 
-.active {
+.button[data-active="true"] {
   border-color: var(--accent);
   color: var(--accent);
 }

--- a/frontend/src/components/Tabs.tsx
+++ b/frontend/src/components/Tabs.tsx
@@ -1,7 +1,6 @@
 import { Fragment, useEffect, useState } from "react";
 import type { ReactElement, ReactNode } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router";
-import clsx from "clsx";
 import { kebabCase } from "lodash";
 import { Content, List, Root, Trigger } from "@radix-ui/react-tabs";
 import { deleteParam, mergeTo } from "@/components/Link";
@@ -72,10 +71,8 @@ const Tabs = ({ syncWithUrl = "", children, defaultValue }: Props) => {
           <Tooltip key={index} content={tab.tooltip}>
             <Trigger
               value={tab.id}
-              className={clsx(
-                classes.button,
-                tab.id === selected && classes.active,
-              )}
+              className={classes.button}
+              data-active={tab.id === selected}
             >
               {tab.text}
               {tab.icon}

--- a/frontend/src/components/Tile.tsx
+++ b/frontend/src/components/Tile.tsx
@@ -15,7 +15,7 @@ type Props = {
 /** big icon and primary and secondary content/text */
 const Tile = ({ icon, primary, secondary }: Props) => {
   return (
-    <Flex direction="column" className={classes.tile}>
+    <Flex column className={classes.tile}>
       {icon}
       <div>
         <div className={clsx("bold", classes.primary)}>{primary}</div>

--- a/frontend/src/components/Toasts.tsx
+++ b/frontend/src/components/Toasts.tsx
@@ -47,7 +47,7 @@ const Toasts = () => {
 
   return (
     <Flex
-      direction="column"
+      column
       hAlign="stretch"
       gap="sm"
       role="region"

--- a/frontend/src/components/ViewCorner.tsx
+++ b/frontend/src/components/ViewCorner.tsx
@@ -9,7 +9,7 @@ const ViewCorner = () => {
   const { y } = useWindowScroll();
 
   return (
-    <Flex direction="column" hAlign="right" gap="sm" className={classes.list}>
+    <Flex column hAlign="right" gap="sm" className={classes.list}>
       <Toasts />
       {y > 100 && (
         <button

--- a/frontend/src/global/styles.css
+++ b/frontend/src/global/styles.css
@@ -164,7 +164,15 @@ blockquote {
 
 /** table */
 
+.table-wrapper {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
 table {
+  overflow: hidden;
+  border: solid 1px var(--light-gray);
+  border-radius: var(--rounded);
   border-collapse: collapse;
 }
 
@@ -181,17 +189,16 @@ td {
   border-right: solid 1px var(--light-gray);
 }
 
-thead tr:nth-child(odd),
+thead tr:nth-child(odd) {
+  background: var(--off-white);
+}
+
 tr:nth-child(even) {
   background: var(--white);
 }
 
 tr:nth-child(odd) {
   background: var(--alt-white);
-}
-
-thead tr {
-  border-bottom: solid 1px var(--light-gray);
 }
 
 /** interactive */

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -19,65 +19,54 @@ import { trim } from "@/util/string";
 const team = [
   {
     name: "Janani Ravi",
-    role: "PI",
     email: "janani.ravi@cuanschutz.edu",
     github: "jananiravi",
   },
   {
     name: "Jacob D Krol",
-    role: "Developer",
     email: "jacob.krol@cuanschutz.edu",
     github: "jakekrol",
   },
   {
     name: "Joseph T Burke",
-    role: "Developer",
     email: "burkej24@msu.edu",
     github: "jburke11",
   },
   {
     name: "Samuel Z Chen",
-    role: "Developer",
     email: "chensam2@msu.edu",
     github: "samuelzornchen",
   },
   {
     name: "Lo Sosinski",
-    role: "Developer",
     email: "sosinsk7@msu.edu",
     github: "lsosinski",
   },
   {
     name: "Faisal S Alquaddoomi",
-    role: "Developer",
     email: "faisal.alquaddoomi@cuanschutz.edu",
     github: "falquaddoomi",
   },
   {
     name: "Evan P Brenner",
-    role: "Developer",
     email: "evan.brenner@cuanschutz.edu",
     github: "epbrenner",
   },
   {
     name: "Vince P Rubinetti",
-    role: "Developer",
     email: "vincent.rubinetti@cuanschutz.edu",
     github: "vincerubinetti",
   },
   {
     name: "Shaddai Amolitos",
-    role: "Developer",
     email: "shaddai.amolitos@cuanschutz.edu",
   },
   {
     name: "Kellen M Reason",
-    role: "Developer",
     email: "reasonke@msu.edu",
   },
   {
     name: "John B Johnston",
-    role: "Developer",
     email: "johnj@msu.edu",
   },
 ];
@@ -471,16 +460,14 @@ const About = () => {
             <thead>
               <tr>
                 <th>Name</th>
-                <th>Role</th>
                 <th>Email</th>
                 <th>GitHub</th>
               </tr>
             </thead>
             <tbody>
-              {team.map(({ name, role, email, github }, index) => (
+              {team.map(({ name, email, github }, index) => (
                 <tr key={index}>
                   <td>{name}</td>
-                  <td>{role}</td>
                   <td>
                     {email && (
                       <Link to={`mailto:${email}`}>

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -6,7 +6,6 @@ import {
   FaGithub,
   FaMicroscope,
   FaPenNib,
-  FaTwitter,
   FaUsers,
 } from "react-icons/fa6";
 import Button from "@/components/Button";
@@ -19,58 +18,66 @@ import { trim } from "@/util/string";
 
 const team = [
   {
-    name: "Janani Ravi (corresponding author)",
+    name: "Janani Ravi",
+    role: "PI",
     email: "janani.ravi@cuanschutz.edu",
     github: "jananiravi",
-    twitter: "janani137",
   },
   {
     name: "Jacob D Krol",
+    role: "Developer",
     email: "jacob.krol@cuanschutz.edu",
     github: "jakekrol",
   },
   {
     name: "Joseph T Burke",
+    role: "Developer",
     email: "burkej24@msu.edu",
     github: "jburke11",
   },
   {
     name: "Samuel Z Chen",
+    role: "Developer",
     email: "chensam2@msu.edu",
     github: "samuelzornchen",
-    twitter: "SamuelZChen",
   },
   {
     name: "Lo Sosinski",
+    role: "Developer",
     email: "sosinsk7@msu.edu",
     github: "lsosinski",
-    twitter: "lo_sosinski",
   },
   {
     name: "Faisal S Alquaddoomi",
+    role: "Developer",
     email: "faisal.alquaddoomi@cuanschutz.edu",
     github: "falquaddoomi",
   },
   {
     name: "Evan P Brenner",
+    role: "Developer",
     email: "evan.brenner@cuanschutz.edu",
     github: "epbrenner",
   },
   {
     name: "Vince P Rubinetti",
+    role: "Developer",
     email: "vincent.rubinetti@cuanschutz.edu",
     github: "vincerubinetti",
   },
   {
     name: "Shaddai Amolitos",
+    role: "Developer",
     email: "shaddai.amolitos@cuanschutz.edu",
   },
   {
     name: "Kellen M Reason",
+    role: "Developer",
     email: "reasonke@msu.edu",
   },
   {
     name: "John B Johnston",
+    role: "Developer",
     email: "johnj@msu.edu",
   },
 ];
@@ -91,11 +98,12 @@ const About = () => {
           FAQs
         </Heading>
 
-        <Heading level={3}>
-          How will I know when my analysis is done? Where are my past analyses?
-        </Heading>
+        <Flex column full>
+          <Heading level={3}>
+            How will I know when my analysis is done? Where are my past
+            analyses?
+          </Heading>
 
-        <Flex direction="column" gap="sm" full>
           <p>
             When you submit an analysis, you'll be taken to a dedicated page for
             it where you can its status, and eventually, the results. You can
@@ -114,9 +122,9 @@ const About = () => {
           </p>
         </Flex>
 
-        <Heading level={3}>When can I expect my results?</Heading>
+        <Flex column gap="sm" full>
+          <Heading level={3}>When can I expect my results?</Heading>
 
-        <Flex direction="column" gap="sm" full>
           <p>
             The time it takes to complete an analysis can be as little as a few
             minutes or as much as a few hours. It depends on many factors, such
@@ -135,9 +143,9 @@ const About = () => {
           </p>
         </Flex>
 
-        <Heading level={3}>How do I upload protein sequences?</Heading>
+        <Flex column gap="sm" full>
+          <Heading level={3}>How do I upload protein sequences?</Heading>
 
-        <Flex direction="column" gap="sm" full>
           <p>
             <strong>Protein sequence formats</strong> we support:
           </p>
@@ -248,84 +256,83 @@ const About = () => {
           Behind MolEvolvR
         </Heading>
 
-        <Heading level={3}>Data sources</Heading>
+        <div className="grid cols-2">
+          <Flex column gap="sm">
+            <Heading level={3}>Data sources</Heading>
 
-        <ul>
-          <li>NCBI Taxonomy</li>
-          <li>NCBI GenBank/RefSeq</li>
-          <li>BLAST RefSeq</li>
-          <li>NR DB</li>
-          <li>InterPro</li>
-        </ul>
+            <ul>
+              <li>NCBI Taxonomy</li>
+              <li>NCBI GenBank/RefSeq</li>
+              <li>BLAST RefSeq</li>
+              <li>NR DB</li>
+              <li>InterPro</li>
+            </ul>
+          </Flex>
 
-        <Heading level={3}>Technologies</Heading>
+          <Flex column gap="sm">
+            <Heading level={3}>Technologies</Heading>
 
-        <Flex direction="column" gap="sm" full>
-          <p>
-            MolEvolvR is a coordination of several different technologies,
-            consisting of:
-          </p>
+            <p>
+              MolEvolvR is a coordination of several different technologies,
+              consisting of:
+            </p>
 
-          <ul>
-            <li>
-              <strong>
-                <Link to="https://github.com/JRaviLab/molevolvr">
-                  MolEvolvR package
-                </Link>
-              </strong>{" "}
-              &ndash; the R package at the core of everything, which does most
-              of the analysis calculations
-            </li>
-            <li>
-              <strong>Frontend</strong> &ndash; a web app written in React
-            </li>
+            <ul>
+              <li>
+                <strong>
+                  <Link to="https://github.com/JRaviLab/molevolvr">
+                    MolEvolvR package
+                  </Link>
+                </strong>{" "}
+                &ndash; the R package at the core of everything, which does most
+                of the analysis calculations
+              </li>
+              <li>
+                <strong>Frontend</strong> &ndash; a web app written in React
+              </li>
 
-            <li>
-              <strong>Backend</strong> &ndash; a backend written in{" "}
-              <Link to="https://www.rplumber.io/index.html">Plumber</Link>
-            </li>
+              <li>
+                <strong>Backend</strong> &ndash; a backend written in{" "}
+                <Link to="https://www.rplumber.io/index.html">Plumber</Link>
+              </li>
 
-            <li>
-              <strong>Cluster</strong> &ndash; a containerized SLURM cluster on
-              which jobs are run
-            </li>
+              <li>
+                <strong>Cluster</strong> &ndash; a containerized SLURM cluster
+                on which jobs are run
+              </li>
 
-            <li>
-              <strong>Postgres</strong> &ndash; configuration for a database
-              which stores job information
-            </li>
-          </ul>
-        </Flex>
+              <li>
+                <strong>Postgres</strong> &ndash; configuration for a database
+                which stores job information
+              </li>
+            </ul>
+          </Flex>
 
-        <Heading level={3}>Compatibility</Heading>
+          <Flex column gap="sm">
+            <Heading level={3}>Compatibility</Heading>
 
-        <Flex direction="column" gap="sm" full>
-          <p>This web-app is regularly tested on the following:</p>
+            <p>This web-app is regularly tested on the following:</p>
 
-          <ul>
-            <li>Google Chrome, Mozilla Firefox, Apple Safari</li>
-            <li>Windows, MacOS, iOS, Android</li>
-            <li>Desktop, tablet, phone/mobile</li>
-          </ul>
+            <ul>
+              <li>Google Chrome, Mozilla Firefox, Apple Safari</li>
+              <li>Windows, MacOS, iOS, Android</li>
+              <li>Desktop, tablet, phone/mobile</li>
+            </ul>
 
-          <p>
-            The following are NOT supported, and may result in unexpected look
-            or behavior:
-          </p>
+            <p>
+              The following are NOT supported, and may result in unexpected look
+              or behavior:
+            </p>
 
-          <ul>
-            <li>Internet Explorer</li>
-            <li>
-              Smart watches, or any device with a screen width {"<"} ~250px
-            </li>
-            <li>Browsers without JavaScript enabled</li>
-          </ul>
-
-          <p>
-            If you encounter a bug, please{" "}
-            <Link to="mailto:janani.ravi@cuanschutz.edu">let us know</Link>!
-          </p>
-        </Flex>
+            <ul>
+              <li>Internet Explorer</li>
+              <li>
+                Smart watches, or any device with a screen width {"<"} ~250px
+              </li>
+              <li>Browsers without JavaScript enabled</li>
+            </ul>
+          </Flex>
+        </div>
       </Section>
 
       <Section>
@@ -333,7 +340,7 @@ const About = () => {
           Case studies
         </Heading>
 
-        <Flex direction="column" gap="sm" full>
+        <Flex column gap="sm">
           <p>
             The computational methods underlying MolEvolvR have enabled
             understanding fundamental biological systems and protein evolution.
@@ -345,101 +352,111 @@ const About = () => {
           </p>
         </Flex>
 
-        <Flex direction="column" full>
-          <Heading level={3}>
-            Surface layer proteins in Gram-positive bacteria (Bacillota)
-          </Heading>
+        <div className="grid cols-2">
+          <Flex column gap="sm">
+            <Heading level={3}>
+              Surface layer proteins in Gram-positive bacteria (Bacillota)
+            </Heading>
 
-          <ul>
-            <li>
-              <Link to="https://doi.org/10.3389%2Ffmicb.2021.663468">
-                Publication
-              </Link>
-            </li>
+            <ul>
+              <li>
+                <Link to="https://doi.org/10.3389%2Ffmicb.2021.663468">
+                  Publication
+                </Link>
+              </li>
 
-            <li>
-              <Link to="https://jravilab.cuanschutz.edu/molevolvr/?r=slayer&p=resultsSummary">
-                MolEvolvR results
-              </Link>
-            </li>
-          </ul>
+              <li>
+                <Link to="https://jravilab.cuanschutz.edu/molevolvr/?r=slayer&p=resultsSummary">
+                  MolEvolvR results
+                </Link>
+              </li>
+            </ul>
 
-          <Heading level={3}>Helicase operators in bacteria</Heading>
+            <Heading level={3}>Helicase operators in bacteria</Heading>
 
-          <ul>
-            <li>
-              <Link to="https://doi.org/10.1128/jb.00163-22">Publication</Link>
-            </li>
+            <ul>
+              <li>
+                <Link to="https://doi.org/10.1128/jb.00163-22">
+                  Publication
+                </Link>
+              </li>
 
-            <li>
-              <Link to="https://jravilab.cuanschutz.edu/molevolvr/?r=dciahe&p=resultsSummary">
-                MolEvolvR results
-              </Link>
-            </li>
-          </ul>
+              <li>
+                <Link to="https://jravilab.cuanschutz.edu/molevolvr/?r=dciahe&p=resultsSummary">
+                  MolEvolvR results
+                </Link>
+              </li>
+            </ul>
 
-          <Heading level={3}>Novel internalin P homologs in Listeria</Heading>
+            <Heading level={3}>Novel internalin P homologs in Listeria</Heading>
 
-          <ul>
-            <li>
-              <Link to="https://doi.org/10.1099/mgen.0.000828">
-                Publication
-              </Link>
-            </li>
+            <ul>
+              <li>
+                <Link to="https://doi.org/10.1099/mgen.0.000828">
+                  Publication
+                </Link>
+              </li>
 
-            <li>
-              <Link to="https://jravilab.cuanschutz.edu/molevolvr/?r=liinlp&p=resultsSummary">
-                MolEvolvR results
-              </Link>
-            </li>
-          </ul>
+              <li>
+                <Link to="https://jravilab.cuanschutz.edu/molevolvr/?r=liinlp&p=resultsSummary">
+                  MolEvolvR results
+                </Link>
+              </li>
+            </ul>
+          </Flex>
 
-          <Heading level={3}>Staphylococcus aureus sulfur acquisition</Heading>
+          <Flex column gap="sm">
+            <Heading level={3}>
+              Staphylococcus aureus sulfur acquisition
+            </Heading>
 
-          <Heading level={4}>Glutathione import system</Heading>
+            <Heading level={4}>Glutathione import system</Heading>
 
-          <ul>
-            <li>
-              <Link to="https://doi.org/10.1371/journal.pgen.1010834">
-                Publication
-              </Link>
-            </li>
-            <li>
-              <Link to="https://jravilab.cuanschutz.edu/molevolvr/?r=sasulf&p=resultsSummary">
-                MolEvolvR results
-              </Link>
-            </li>
-          </ul>
+            <ul>
+              <li>
+                <Link to="https://doi.org/10.1371/journal.pgen.1010834">
+                  Publication
+                </Link>
+              </li>
+              <li>
+                <Link to="https://jravilab.cuanschutz.edu/molevolvr/?r=sasulf&p=resultsSummary">
+                  MolEvolvR results
+                </Link>
+              </li>
+            </ul>
 
-          <Heading level={4}>Cystine transporters</Heading>
+            <Heading level={4}>Cystine transporters</Heading>
 
-          <ul>
-            <li>
-              <Link to="https://doi.org/10.1128/iai.00690-19">Publication</Link>
-            </li>
-            <li>
-              <Link to="https://jravilab.cuanschutz.edu/molevolvr/?r=saabct&p=resultsSummary">
-                MolEvolvR results
-              </Link>
-            </li>
-          </ul>
+            <ul>
+              <li>
+                <Link to="https://doi.org/10.1128/iai.00690-19">
+                  Publication
+                </Link>
+              </li>
+              <li>
+                <Link to="https://jravilab.cuanschutz.edu/molevolvr/?r=saabct&p=resultsSummary">
+                  MolEvolvR results
+                </Link>
+              </li>
+            </ul>
 
-          <Heading level={4}>V. cholerae phage defense system</Heading>
+            <Heading level={4}>V. cholerae phage defense system</Heading>
 
-          <ul>
-            <li>
-              <Link to="https://doi.org/10.1038/s41564-022-01162-4">
-                Publication
-              </Link>
-            </li>
-            <li>
-              {" "}
-              <Link to="https://jravilab.cuanschutz.edu/molevolvr/?r=vcpdef&p=resultsSummary">
-                MolEvolvR results
-              </Link>
-            </li>
-          </ul>
-        </Flex>
+            <ul>
+              <li>
+                <Link to="https://doi.org/10.1038/s41564-022-01162-4">
+                  Publication
+                </Link>
+              </li>
+              <li>
+                {" "}
+                <Link to="https://jravilab.cuanschutz.edu/molevolvr/?r=vcpdef&p=resultsSummary">
+                  MolEvolvR results
+                </Link>
+              </li>
+            </ul>
+          </Flex>
+        </div>
       </Section>
 
       <Section>
@@ -449,31 +466,44 @@ const About = () => {
 
         <Heading level={3}>Team</Heading>
 
-        <ul>
-          {team.map(({ name, email, github, twitter }, index) => (
-            <li key={index}>
-              <Flex hAlign="left" gap="sm" gapRatio={0}>
-                <span>{name}</span>
-                {email && (
-                  <Link to={`mailto:${email}`}>
-                    <FaEnvelope />
-                    {email}
-                  </Link>
-                )}
-                {github && (
-                  <Link to={`https://github.com/${github}`} showArrow={false}>
-                    <FaGithub />@{github}
-                  </Link>
-                )}
-                {twitter && (
-                  <Link to={`https://twitter.com/${twitter}`} showArrow={false}>
-                    <FaTwitter />@{twitter}
-                  </Link>
-                )}
-              </Flex>
-            </li>
-          ))}
-        </ul>
+        <div className="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Role</th>
+                <th>Email</th>
+                <th>GitHub</th>
+              </tr>
+            </thead>
+            <tbody>
+              {team.map(({ name, role, email, github }, index) => (
+                <tr key={index}>
+                  <td>{name}</td>
+                  <td>{role}</td>
+                  <td>
+                    {email && (
+                      <Link to={`mailto:${email}`}>
+                        <FaEnvelope />
+                        {email}
+                      </Link>
+                    )}
+                  </td>
+                  <td>
+                    {github && (
+                      <Link
+                        to={`https://github.com/${github}`}
+                        showArrow={false}
+                      >
+                        <FaGithub />@{github}
+                      </Link>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
 
         <Heading level={3}>Funding</Heading>
 
@@ -486,35 +516,34 @@ const About = () => {
           to EPB.
         </p>
 
-        <Heading level={3}>Contact</Heading>
+        <Flex column gap="sm">
+          <Heading level={3}>Contact</Heading>
 
-        <Flex hAlign="left" full>
-          <Button
-            to="mailto:janani.ravi@cuanschutz.edu"
-            text="janani.ravi@cuanschutz.edu"
-            icon={<FaEnvelope />}
-          />
+          <Flex>
+            <Button
+              to="mailto:janani.ravi@cuanschutz.edu"
+              text="janani.ravi@cuanschutz.edu"
+              icon={<FaEnvelope />}
+            />
+          </Flex>
         </Flex>
 
-        <Heading level={3}>Follow</Heading>
+        <Flex column gap="sm">
+          <Heading level={3}>Follow</Heading>
 
-        <Flex hAlign="left" full>
-          <Button
-            to="https://jravilab.github.io/"
-            text="JRaviLab"
-            icon={<FaMicroscope />}
-            tooltip="JRaviLab website"
-          />
-          <Button
-            to="https://github.com/jravilab"
-            text="GitHub"
-            icon={<FaGithub />}
-          />
-          <Button
-            to="https://twitter.com/jravilab"
-            text="Twitter"
-            icon={<FaTwitter />}
-          />
+          <Flex>
+            <Button
+              to="https://jravilab.github.io/"
+              text="JRaviLab"
+              icon={<FaMicroscope />}
+              tooltip="JRaviLab website"
+            />
+            <Button
+              to="https://github.com/jravilab"
+              text="GitHub"
+              icon={<FaGithub />}
+            />
+          </Flex>
         </Flex>
       </Section>
     </>

--- a/frontend/src/pages/NewAnalysis.tsx
+++ b/frontend/src/pages/NewAnalysis.tsx
@@ -233,7 +233,7 @@ const NewAnalysis = () => {
               name="inputFormat"
             />
 
-            <Flex direction="column" hAlign="left">
+            <Flex column hAlign="left">
               <SelectSingle
                 label="What format is your input in?"
                 layout="vertical"
@@ -334,7 +334,7 @@ const NewAnalysis = () => {
           </Flex>
 
           {inputType === "external" && (
-            <Flex direction="column">
+            <Flex column>
               <CheckBox
                 label={
                   <span>
@@ -396,7 +396,7 @@ const NewAnalysis = () => {
             />
 
             {["homology-domain", "homology"].includes(analysisType) && (
-              <Flex direction="column" hAlign="left">
+              <Flex column hAlign="left">
                 <div className="primary">BLAST Parameters</div>
 
                 <SelectSingle

--- a/frontend/src/pages/Testbed.tsx
+++ b/frontend/src/pages/Testbed.tsx
@@ -665,7 +665,7 @@ const SectionAlert = () => (
       Alert
     </Heading>
 
-    <Flex direction="column">
+    <Flex column>
       <Alert>
         Lorem ipsum dolor sit amet consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua.

--- a/frontend/src/util/dom.ts
+++ b/frontend/src/util/dom.ts
@@ -85,10 +85,15 @@ export const firstInView = (elements: HTMLElement[]) => {
   const offset = parseInt(
     window.getComputedStyle(document.documentElement).scrollPaddingTop,
   );
-  for (const element of elements.reverse())
-    if (element.getBoundingClientRect()?.top < offset + 40) return element;
-};
+  for (let index = elements.length - 1; index >= 0; index--)
+    if (
+      elementOrSection(elements[index]!).getBoundingClientRect()?.top <
+      offset + 5
+    )
+      return index;
 
+  return 0;
+};
 /** shrink width to wrapped text https://stackoverflow.com/questions/14596213 */
 export const shrinkWrap = (
   element: HTMLElement | null,
@@ -227,7 +232,9 @@ export const glow = (element: Element) =>
   );
 
 /** if element is first child of section, change element to section itself */
-const elementOrSection = (element: Element) => {
+export const elementOrSection = <El extends Element>(element: El) => {
   const parent = element.parentElement;
-  return parent && element.matches("section > :first-child") ? parent : element;
+  return parent && element.matches("section > :first-child")
+    ? (parent as HTMLElement)
+    : element;
 };


### PR DESCRIPTION
- simplify flex component props, e.g. `direction="column"` -> `column`, since it's used everywhere. find+replace whole app.
- change heading component to register/unregister itself in global list of headings
- consistent use of data attribute for active state styles
- tweak table of contents styles
- instead of requerying for all headings on any document mutation (expensive\*), render table of contents from global reactive list of headings
- include icons in table of contents entries
- clean up and compactify about page (original impetus for making TOC look and behave better)

\* On any modern machine though, probably not a humanly perceptible difference. Also the expense will be limited by the fact that we should never have as many things on one page as is currently on the testbed page.